### PR TITLE
Fix 4 locations with null URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1991,13 +1991,13 @@
                 url: "https://wegmans.com"
             },
             {
-                name: "Buy Rite Liquors - Jersey City",
+                name: "Jersey City Super Buy Rite",
                 category: "retailer",
                 lat: 40.7282,
                 lng: -74.0776,
-                location: "Jersey City, NJ",
-                description: "Well-stocked craft beer selection with regular Lawson's Finest availability.",
-                url: null
+                location: "575 Manila Ave, Jersey City, NJ",
+                description: "New Jersey's largest liquor store with over 30,000 sq ft and one of the largest beer selections in the world. Fresh Lawson's regularly in stock.",
+                url: "https://buyritewines.com/"
             },
             // Additional Pennsylvania
             {
@@ -2020,13 +2020,13 @@
             },
             // Additional Virginia
             {
-                name: "Corks & Kegs - Leesburg",
+                name: "Total Wine & More - Leesburg",
                 category: "retailer",
                 lat: 39.1157,
                 lng: -77.5636,
-                location: "Leesburg, VA",
-                description: "Northern Virginia craft beer destination with 500+ craft selections including Lawson's.",
-                url: null
+                location: "1610 Village Market Blvd, Leesburg, VA",
+                description: "Northern Virginia craft beer destination with extensive selection. Fresh Lawson's Sip of Sunshine regularly in stock.",
+                url: "https://www.totalwine.com/store-info/virginia-leesburg/218"
             },
             {
                 name: "Whole Foods Market - Fairfax",
@@ -2047,13 +2047,13 @@
                 url: "https://beerrun.com"
             },
             {
-                name: "Staunton Grocery",
+                name: "The Staunton Grocery",
                 category: "retailer",
                 lat: 38.1496,
                 lng: -79.0717,
-                location: "Staunton, VA",
-                description: "Boutique grocery in the Shenandoah Valley with craft beer selection. Near Skyline Drive.",
-                url: null
+                location: "103 S Coalter St, Staunton, VA",
+                description: "Boutique grocery in the Shenandoah Valley with curated craft beer selection. Near Skyline Drive entrance.",
+                url: "https://thestauntongrocery.shopsettings.com/"
             },
             // Additional North Carolina
             {
@@ -2075,13 +2075,13 @@
                 url: "https://goodbottleco.com"
             },
             {
-                name: "Craft - Asheville",
+                name: "Wedge Brewing - Grove Arcade",
                 category: "retailer",
                 lat: 35.5923,
                 lng: -82.5574,
-                location: "Asheville, NC",
-                description: "Grove Arcade location with rotating craft beer and fresh Lawson's from Artisan Beverage Group.",
-                url: null
+                location: "1 Page Ave, Suite 152, Asheville, NC",
+                description: "Historic Grove Arcade taproom featuring Asheville-brewed craft beers. Great selection of local and regional brews including Lawson's.",
+                url: "https://wedgebrewing.com/locations/grove-arcade/"
             },
             // Rhode Island
             {


### PR DESCRIPTION
- Buy Rite Liquors Jersey City: added buyritewines.com
- Corks & Kegs Leesburg: renamed to Total Wine Leesburg with URL
- Staunton Grocery: added thestauntongrocery.shopsettings.com
- Craft Asheville: renamed to Wedge Brewing Grove Arcade with URL